### PR TITLE
Create prog8compiler.jar with fatjar like jar process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ compiler/src/compiled_java
 
 .gradle
 build/
+/prog8compiler.jar

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -55,3 +55,14 @@ applicationDistribution.into("bin") {
             from(p8vmScript)
             fileMode = 0755
 }
+
+task fatJar(type: Jar) {
+    manifest {
+        attributes 'Main-Class': 'prog8.CompilerMainKt'
+    }
+    archiveBaseName = 'prog8compiler'
+    destinationDir = rootProject.projectDir
+    from { project.configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) } }
+    with jar
+}
+build.finalizedBy(fatJar)


### PR DESCRIPTION
Creates a jar with all dependencies on after each full build.
Remove `build.finalizedBy(fatJar)` line to manual only usage with `./gradlew fatJar`