### PR TITLE
Move code used for all Commodore systems to new package

### DIFF
--- a/compiler/src/prog8/compiler/target/ICompilationTarget.kt
+++ b/compiler/src/prog8/compiler/target/ICompilationTarget.kt
@@ -11,7 +11,7 @@ import prog8.compiler.CompilationOptions
 import prog8.compiler.IErrorReporter
 import prog8.compiler.Zeropage
 import prog8.compiler.target.c64.C64MachineDefinition
-import prog8.compiler.target.c64.Petscii
+import prog8.compiler.target.cbm.Petscii
 import prog8.compiler.target.cpu6502.codegen.AsmGen
 import prog8.compiler.target.cx16.CX16MachineDefinition
 import java.nio.file.Path

--- a/compiler/src/prog8/compiler/target/cbm/AssemblyProgram.kt
+++ b/compiler/src/prog8/compiler/target/cbm/AssemblyProgram.kt
@@ -1,4 +1,4 @@
-package prog8.compiler.target.c64
+package prog8.compiler.target.cbm
 
 import prog8.compiler.CompilationOptions
 import prog8.compiler.OutputType

--- a/compiler/src/prog8/compiler/target/cbm/Petscii.kt
+++ b/compiler/src/prog8/compiler/target/cbm/Petscii.kt
@@ -1,4 +1,4 @@
-package prog8.compiler.target.c64
+package prog8.compiler.target.cbm
 
 import java.io.CharConversionException
 

--- a/compiler/src/prog8/compiler/target/cpu6502/codegen/AsmGen.kt
+++ b/compiler/src/prog8/compiler/target/cpu6502/codegen/AsmGen.kt
@@ -9,8 +9,8 @@ import prog8.compiler.*
 import prog8.compiler.functions.BuiltinFunctions
 import prog8.compiler.functions.FSignature
 import prog8.compiler.target.*
-import prog8.compiler.target.c64.AssemblyProgram
-import prog8.compiler.target.c64.Petscii
+import prog8.compiler.target.cbm.AssemblyProgram
+import prog8.compiler.target.cbm.Petscii
 import prog8.compiler.target.cpu6502.codegen.assignment.AsmAssignment
 import prog8.compiler.target.cpu6502.codegen.assignment.AssignmentAsmGen
 import java.io.CharConversionException


### PR DESCRIPTION
While looking at the code, I noticed that the files AssemblyProgram.kt and Petscii.kt were also used by the Commander X16, despite being placed in the C64 package. Considering that any Commodore systems added to Prog8 in the future will likely also use this code, I think that a better place for it would be in a new package. Please let me know if there is a reason why these files were specific to the C64 package.