### PR TITLE
Fix compiler unit tests by changing Petscii import

### DIFF
--- a/compiler/test/UnitTests.kt
+++ b/compiler/test/UnitTests.kt
@@ -19,7 +19,7 @@ import prog8.compiler.target.c64.C64MachineDefinition.C64Zeropage
 import prog8.compiler.target.c64.C64MachineDefinition.FLOAT_MAX_NEGATIVE
 import prog8.compiler.target.c64.C64MachineDefinition.FLOAT_MAX_POSITIVE
 import prog8.compiler.target.c64.C64MachineDefinition.Mflpt5
-import prog8.compiler.target.c64.Petscii
+import prog8.compiler.target.cbm.Petscii
 import prog8.compiler.target.cx16.CX16MachineDefinition.CX16Zeropage
 import java.io.CharConversionException
 import java.nio.file.Path


### PR DESCRIPTION
Just noticed that moving Petscii to the CBM package breaks the unit tests. This fixes the issue.