### PR TITLE
fixed chrout for atari and added two examples

### DIFF
--- a/compiler/res/prog8lib/atari/textio.p8
+++ b/compiler/res/prog8lib/atari/textio.p8
@@ -21,7 +21,7 @@ sub home() {
 }
 
 sub nl() {
-    txt.chrout('\n')
+    txt.chrout(155)
 }
 
 sub spc() {
@@ -118,7 +118,28 @@ asmsub  scroll_down  (ubyte alsocolors @ Pc) clobbers(A)  {
 }
 
 
-romsub $FFD2 = chrout(ubyte char @ A)    ; TODO
+romsub $F2B0 = outchar(ubyte char @ A)
+romsub $F2Fd = waitkey()
+
+asmsub chrout(ubyte char @ A) {
+	%asm {{
+		sta  _tmp_outchar+1
+		pha
+		txa
+		pha
+		tya
+		pha
+_tmp_outchar
+		lda  #0
+		jsr  outchar
+		pla
+		tay
+		pla
+		tax
+		pla
+		rts
+	}}
+}
 
 asmsub  print (str text @ AY) clobbers(A,Y)  {
 	; ---- print null terminated string from A/Y

--- a/examples/atari/fibonacci.p8
+++ b/examples/atari/fibonacci.p8
@@ -1,0 +1,30 @@
+%import textio
+%zeropage basicsafe
+%address $2000
+
+; This example computes the first 20 values of the Fibonacci sequence.
+; Note: this program is compatible with atari.
+
+main {
+    sub start() {
+        txt.print("fibonacci sequence")
+        txt.nl()
+
+        repeat 21 {
+            txt.print_uw(fib_next())
+            txt.nl()
+        }
+
+		txt.waitkey()
+    }
+
+    uword fib_prev = 0
+    uword fib_current = 1
+
+    sub fib_next() -> uword {
+        uword new = fib_current + fib_prev
+        fib_prev = fib_current
+        fib_current = new
+        return fib_prev
+    }
+}

--- a/examples/atari/hello.p8
+++ b/examples/atari/hello.p8
@@ -1,0 +1,13 @@
+%import textio
+%zeropage basicsafe
+%address $2000
+
+; hello world test for Atari 8-bit
+
+main {
+	sub start() {
+        txt.print("Hello, World!")
+		txt.nl()
+		txt.waitkey()
+    }
+}


### PR DESCRIPTION
I had to add this to the examples:

`%address $2000`

There is probably a better way.

This is my output for fibonacci:
![fibonacci](https://user-images.githubusercontent.com/7803603/155355867-fff7bd0b-ebe9-46c9-bcf7-e52f76e170a3.png)
