### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -68,7 +68,7 @@ It contains all of the program's code and data and has a certain file format tha
 allows it to be loaded directly on the target system.   Prog8 currently has no built-in
 support for programs that exceed 64 Kb of memory, nor for multi-part loaders.
 
-For the Commodore-64, most programs will have a tiny BASIC launcher that does a SYS into the generated machine code.
+For the Commodore 64, most programs will have a tiny BASIC launcher that does a SYS into the generated machine code.
 This way the user can load it as any other program and simply RUN it to start. (This is a regular ".prg" program).
 Prog8 can create those, but it is also possible to output plain binary programs
 that can be loaded into memory anywhere.

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -95,7 +95,7 @@ For normal use the compiler can be invoked with the command:
 
 By default, assembly code is generated and written to ``sourcefile.asm``.
 It is then (automatically) fed to the `64tass <https://sourceforge.net/projects/tass64/>`_ assembler tool
-that creastes the final runnable program.
+that creates the final runnable program.
 
 
 Command line options

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -182,7 +182,7 @@ One or more .p8 module files
 ``-esa <address>``
     Override the base address of the evaluation stack. Has to be page-aligned.
     You can specify an integer or hexadecimal address.
-    When not compiling for the CommanderX16 target, the location of the 16 virtual registers cx16.r0..r15
+    When not compiling for the Commander X16 target, the location of the 16 virtual registers cx16.r0..r15
     is changed accordingly (to keep them in the same memory space as the evaluation stack).
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,7 +15,7 @@ This is a compiled programming language targeting the 8-bit
 `6510 <https://en.wikipedia.org/wiki/MOS_Technology_6510>`_ /
 `65c02 <https://en.wikipedia.org/wiki/MOS_Technology_65C02>`_ microprocessors.
 This CPU is from the late 1970's and early 1980's and was used in many home computers from that era,
-such as the `Commodore-64 <https://en.wikipedia.org/wiki/Commodore_64>`_.
+such as the `Commodore 64 <https://en.wikipedia.org/wiki/Commodore_64>`_.
 The language aims to provide many conveniences over raw assembly code (even when using a macro assembler),
 while still being low level enough to create high performance programs.
 You can compile programs for various machines with this CPU:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -176,7 +176,7 @@ If you're scared of Oracle's licensing terms, most Linux distributions ship Open
 For Windows it's possible to get that as well; check out `AdoptOpenJDK <https://adoptopenjdk.net/>`_ .
 For MacOS you can use the Homebrew system to install a recent version of OpenJDK.
 
-Finally: an **emulator** (or a real machine ofcourse) to test and run your programs on.
+Finally: an **emulator** (or a real machine of course) to test and run your programs on.
 In C64 mode, the compiler assumes the presence of the `Vice emulator <http://vice-emu.sourceforge.net/>`_.
 If you're targeting the CommanderX16 instead, there's a choice of the official `x16emu <https://github.com/commanderx16/x16-emulator>`_
 and the unofficial `box16 <https://github.com/indigodarkwolf/box16>`_  (you can select which one you want to launch

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -178,7 +178,7 @@ For MacOS you can use the Homebrew system to install a recent version of OpenJDK
 
 Finally: an **emulator** (or a real machine of course) to test and run your programs on.
 In C64 mode, the compiler assumes the presence of the `Vice emulator <http://vice-emu.sourceforge.net/>`_.
-If you're targeting the CommanderX16 instead, there's a choice of the official `x16emu <https://github.com/commanderx16/x16-emulator>`_
+If you're targeting the Commander X16 instead, there's a choice of the official `x16emu <https://github.com/commanderx16/x16-emulator>`_
 and the unofficial `box16 <https://github.com/indigodarkwolf/box16>`_  (you can select which one you want to launch
 using the ``-emu`` or ``-emu2`` command line options)
 

--- a/docs/source/libraries.rst
+++ b/docs/source/libraries.rst
@@ -150,7 +150,7 @@ Provides string manipulation routines.
 ``length(str) -> ubyte length``
     Number of bytes in the string. This value is determined during runtime and counts upto
     the first terminating 0 byte in the string, regardless of the size of the string during compilation time.
-    Don't confuse this with ``len`` and ``sizeof``
+    Don't confuse this with ``len`` and ``sizeof``!
 
 ``left(source, length, target)``
     Copies the left side of the source string of the given length to target string.
@@ -176,8 +176,8 @@ Provides string manipulation routines.
     and the index in the string. Or 0+carry bit clear if the character was not found.
 
 ``compare(string1, string2) -> ubyte result``
-    Returns -1, 0 or 1 depeding on wether string1 sorts before, equal or after string2.
-    Note that you can also directly compare strings and string values with eachother
+    Returns -1, 0 or 1 depending on whether string1 sorts before, equal or after string2.
+    Note that you can also directly compare strings and string values with each other
     using ``==``, ``<`` etcetera (it will use string.compare for you under water automatically).
 
 ``copy(from, to) -> ubyte length``

--- a/docs/source/libraries.rst
+++ b/docs/source/libraries.rst
@@ -283,7 +283,7 @@ Use the ``gfx2`` library if you want full-screen graphics or non-monochrome draw
 
 math
 ----
-Low level integer math routines (which you usually don't have to bother with directly, but they are used by the compiler internally).
+Low-level integer math routines (which you usually don't have to bother with directly, but they are used by the compiler internally).
 Pseudo-Random number generators (byte and word).
 Various 8-bit integer trig functions that use lookup tables to quickly calculate sine and cosines.
 Usually a custom lookup table is the way to go if your application needs these,
@@ -337,7 +337,7 @@ and allows you to print it anywhere on the screen.
 
 prog8_lib
 ---------
-Low level language support. You should not normally have to bother with this directly.
+Low-level language support. You should not normally have to bother with this directly.
 The compiler needs it for various built-in system routines.
 
 

--- a/docs/source/libraries.rst
+++ b/docs/source/libraries.rst
@@ -45,7 +45,7 @@ sys (part of syslib)
     system when the program is running.
     The following return values are currently defined:
 
-    - 16 = compiled for CommanderX16 with 65C02 CPU
+    - 16 = compiled for Commander X16 with 65C02 CPU
     - 64 = compiled for Commodore 64 with 6502/6510 CPU
 
 ``exit(returncode)``

--- a/docs/source/libraries.rst
+++ b/docs/source/libraries.rst
@@ -46,7 +46,7 @@ sys (part of syslib)
     The following return values are currently defined:
 
     - 16 = compiled for CommanderX16 with 65C02 CPU
-    - 64 = compiled for Commodore-64 with 6502/6510 CPU
+    - 64 = compiled for Commodore 64 with 6502/6510 CPU
 
 ``exit(returncode)``
     Immediately stops the program and exits it, with the returncode in the A register.
@@ -356,7 +356,7 @@ Full-screen multicolor bitmap graphics routines, available on the Cx16 machine o
 palette  (cx16 only)
 --------------------
 Available for the Cx16 target. Various routines to set the display color palette.
-There are also a few better looking Commodore-64 color palettes available here,
+There are also a few better looking Commodore 64 color palettes available here,
 because the Commander X16's default colors for this (the first 16 colors) are too saturated
 and are quite different than how they looked on a VIC-II chip in a C-64.
 

--- a/docs/source/portingguide.rst
+++ b/docs/source/portingguide.rst
@@ -50,7 +50,7 @@ ROM routines
 ------------
 #. provide a list of the core ROM routines on the system, with names, addresses, and call signatures.
 
-Ideally there are at least some routines to manipulate the screen and get some user input(clear, print text, print numbers, input strings from the keyboard)
+Ideally there are at least some routines to manipulate the screen and get some user input (clear, print text, print numbers, input strings from the keyboard)
 Routines to initialize the system to a sane state and to do a warm reset are useful too.
 The more the merrier.
 

--- a/docs/source/portingguide.rst
+++ b/docs/source/portingguide.rst
@@ -74,7 +74,7 @@ the new target system.
 
 There are several other support libraries that you may want to port (``diskio``, ``graphics`` to name a few).
 
-Also ofcourse if there are unique things available on the new target system, don't hesitate to provide
+Also of course if there are unique things available on the new target system, don't hesitate to provide
 extensions to the ``syslib`` or perhaps a new special custom library altogether.
 
 

--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -907,7 +907,7 @@ memory(name, size, alignment)
     You can only treat it as a pointer or use it in inline assembly.
 
 callfar(bank, address, argumentaddress)      ; NOTE: specific to cx16 target for now
-    Calls an assembly routine in another ram-bank on the CommanderX16 (using the ``jsrfar`` routine)
+    Calls an assembly routine in another ram-bank on the Commander X16 (using the ``jsrfar`` routine)
     The banked RAM is located in the address range $A000-$BFFF (8 kilobyte), but you can specify
     any address in system ram (why this can be useful is explained at the end of this paragraph)
     The third argument can be used to designate the memory address
@@ -921,7 +921,7 @@ callfar(bank, address, argumentaddress)      ; NOTE: specific to cx16 target for
     This is not very efficient though, so maybe you should write a small piece of inline assembly for this instead.
 
 callrom(bank, address, argumentaddress)      ; NOTE: specific to cx16 target for now
-    Calls an assembly routine in another rom-bank on the CommanderX16
+    Calls an assembly routine in another rom-bank on the Commander X16
     The banked ROM is located in the address range $C000-$FFFF (16 kilobyte).
     There are 32 banks (0 to 31).
     The third argument can be used to designate the memory address

--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -260,7 +260,7 @@ Floating point numbers
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Floats are stored in the 5-byte 'MFLPT' format that is used on CBM machines,
-and currently all floating point operations are specific to the Commodore-64.
+and currently all floating point operations are specific to the Commodore 64.
 This is because routines in the C-64 BASIC and KERNAL ROMs are used for that.
 So floating point operations will only work if the C-64 BASIC ROM (and KERNAL ROM)
 are banked in.

--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -845,18 +845,18 @@ pokemon(address, value)
     Doesn't have anything to do with a certain video game.
 
 push(value)
-    pushes a byte value on the CPU hardware stack. Lowlevel function that should normally not be used.
+    pushes a byte value on the CPU hardware stack. Low-level function that should normally not be used.
 
 pushw(value)
-    pushes a 16-bit word value on the CPU hardware stack. Lowlevel function that should normally not be used.
+    pushes a 16-bit word value on the CPU hardware stack. Low-level function that should normally not be used.
 
 pop(variable)
     pops a byte value off the CPU hardware stack into the given variable. Only variables can be used.
-    Lowlevel function that should normally not be used.
+    Low-level function that should normally not be used.
 
 popw(value)
     pops a 16-bit word value off the CPU hardware stack into the given variable. Only variables can be used.
-    Lowlevel function that should normally not be used.
+    Low-level function that should normally not be used.
 
 rol(x)
     Rotate the bits in x (byte or word) one position to the left.

--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -108,7 +108,7 @@ Be careful when importing other modules; blocks in your own code cannot have
 the same name as a block defined in an imported module or library.
 
 If you omit both the name and address, the entire block is *ignored* by the compiler (and a warning is displayed).
-This is a way to quickly "comment out" a piece of code that is unfinshed or may contain errors that you
+This is a way to quickly "comment out" a piece of code that is unfinished or may contain errors that you
 want to work on later, because the contents of the ignored block are not fully parsed either.
 
 The address can be used to place a block at a specific location in memory.
@@ -353,7 +353,7 @@ It can be correctly displayed on the screen only if a iso-8859-15 charset has be
 
 You can concatenate two string literals using '+', which can be useful to
 split long strings over separate lines. But remember that the length
-of the total string still cannot exceed 255 characaters.
+of the total string still cannot exceed 255 characters.
 A string literal can also be repeated a given number of times using '*', where the repeat number must be a constant value.
 And a new string value can be assigned to another string, but no bounds check is done
 so be sure the destination string is large enough to contain the new value (it is overwritten in memory)::
@@ -370,7 +370,7 @@ as newlines, quote characters themselves, and so on. The ones used most often ar
 ``\\``, ``\"``, ``\n``, ``\r``.  For a detailed description of all of them and what they mean,
 read the syntax reference on strings.
 
-Using the ``in`` operator you can easily check if a characater is present in a string,
+Using the ``in`` operator you can easily check if a character is present in a string,
 example: ``if '@' in email_address {....}`` (however this gives no clue about the location
 in the string where the character is present, if you need that, use the ``string.find()``
 library function instead)
@@ -412,10 +412,10 @@ for the constant itself). This is only valid for the simple numeric types (byte,
 When using ``&`` (the address-of operator but now applied to a datatype), the variable will point to specific location in memory,
 rather than being newly allocated. The initial value (mandatory) must be a valid
 memory address.  Reading the variable will read the given data type from the
-address you specified, and setting the varible will directly modify that memory location(s)::
+address you specified, and setting the variable will directly modify that memory location(s)::
 
 	const  byte  max_age = 2000 - 1974      ; max_age will be the constant value 26
-	&word  SCREENCOLORS = $d020             ; a 16-bit word at the addres $d020-$d021
+	&word  SCREENCOLORS = $d020             ; a 16-bit word at the address $d020-$d021
 
 .. _pointervars_programming:
 
@@ -511,7 +511,7 @@ Conditional Execution
 if statements
 ^^^^^^^^^^^^^
 
-Conditional execution means that the flow of execution changes based on certiain conditions,
+Conditional execution means that the flow of execution changes based on certain conditions,
 rather than having fixed gotos or subroutine calls::
 
     if xx==5 {
@@ -567,7 +567,7 @@ So ``if_cc goto target`` will directly translate into the single CPU instruction
 .. caution::
     These special ``if_XX`` branching statements are only useful in certain specific situations where you are *certain*
     that the status register (still) contains the correct status bits.
-    This is not always the case after a fuction call or other operations!
+    This is not always the case after a function call or other operations!
     If in doubt, check the generated assembly code!
 
 .. note::
@@ -643,7 +643,7 @@ If possible, the expression is parsed and evaluated by the compiler itself at co
 Expressions that cannot be compile-time evaluated will result in code that calculates them at runtime.
 Expressions can contain procedure and function calls.
 There are various built-in functions such as sin(), cos() that can be used in expressions (see :ref:`builtinfunctions`).
-You can also reference idendifiers defined elsewhere in your code.
+You can also reference identifiers defined elsewhere in your code.
 
 Read the :ref:`syntaxreference` chapter for all details on the available operators and kinds of expressions you can write.
 
@@ -680,7 +680,7 @@ Logical expressions are expressions that calculate a boolean result: true or fal
 logical expressions will compile more efficiently than when you're using regular integer type operands
 (because these have to be converted to 0 or 1 every time)
 
-You can use parentheses to group parts of an expresion to change the precedence.
+You can use parentheses to group parts of an expression to change the precedence.
 Usually the normal precedence rules apply (``*`` goes before ``+`` etc.) but subexpressions
 within parentheses will be evaluated first. So ``(4 + 8) * 2`` is 24 and not 20,
 and ``(true or false) and false`` is false instead of true.

--- a/docs/source/syntaxreference.rst
+++ b/docs/source/syntaxreference.rst
@@ -150,7 +150,7 @@ Directives
     The assembler will include the file as raw assembly source text at this point,
     prog8 will not process this at all. Symbols defined in the included assembly can not be referenced
     from prog8 code. However they can be referenced from other assembly code if properly prefixed.
-    You can ofcourse use a label in your prog8 code just before the %asminclude directive, and reference
+    You can of course use a label in your prog8 code just before the %asminclude directive, and reference
     that particular label to get to (the start of) the included assembly.
     Be careful: you risk symbol redefinitions or duplications if you include a piece of
     assembly into a prog8 block that already defines symbols itself.

--- a/docs/source/syntaxreference.rst
+++ b/docs/source/syntaxreference.rst
@@ -8,7 +8,7 @@ Module file
 -----------
 
 This is a file with the ``.p8`` suffix, containing *directives* and *code blocks*, described below.
-The file is a text file wich can also contain:
+The file is a text file which can also contain:
 
 Lines, whitespace, indentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ Directives
 	Global setting, selects the program launcher stub to use.
 	Only relevant when using the ``prg`` output type. Defaults to ``basic``.
 
-	- type ``basic`` : add a tiny C64 BASIC program, whith a SYS statement calling into the machine code
+	- type ``basic`` : add a tiny C64 BASIC program, with a SYS statement calling into the machine code
 	- type ``none`` : no launcher logic is added at all
 
 .. data:: %zeropage <style>
@@ -225,7 +225,7 @@ and after that, a combination of letters, numbers, or underscores. Examples of v
 Code blocks
 -----------
 
-A named block of actual program code. Itefines a *scope* (also known as 'namespace') and
+A named block of actual program code. It defines a *scope* (also known as 'namespace') and
 can only contain *directives*, *variable declarations*, *subroutines* or *inline assembly*::
 
     <blockname> [<address>] {
@@ -270,7 +270,7 @@ Variable declarations
 
 Variables should be declared with their exact type and size so the compiler can allocate storage
 for them. You can give them an initial value as well. That value can be a simple literal value,
-or an expression. If you don't provide an intial value yourself, zero will be used.
+or an expression. If you don't provide an initial value yourself, zero will be used.
 You can add a ``@zp`` zeropage-tag, to tell the compiler to prioritize it
 when selecting variables to be put into zeropage (but no guarantees). If the ZP is full,
 the variable will be allocated in normal memory elsewhere.
@@ -505,7 +505,7 @@ logical:  ``not``  ``and``  ``or``  ``xor``
 		the ``bool`` variable type instead, where this conversion doesn't need to occur.
 
 	.. note::
-		Unlike most other programming languages, there is no short-cirquit or McCarthy-evaluation
+		Unlike most other programming languages, there is no short-circuit or McCarthy evaluation
 		for the logical ``and`` and ``or`` operators. This means that prog8 currently always evaluates
 		all operands from these logical expressions, even when one of them already determines the outcome!
 
@@ -765,7 +765,7 @@ Conditional Execution and Jumps
 Unconditional jump: goto
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-To jump to another part of the program, you use a ``goto`` statement with an addres or the name
+To jump to another part of the program, you use a ``goto`` statement with an address or the name
 of a label or subroutine::
 
     goto  $c000     ; address
@@ -806,7 +806,7 @@ However if <statements> is a block of multiple statements, you'll have to enclos
 **Special status register branch form:**
 
 There is a special form of the if-statement that immediately translates into one of the 6502's branching instructions.
-It is almost the same as the regular if-statement but it lacks a contional expression part, because the if-statement
+It is almost the same as the regular if-statement but it lacks a conditional expression part, because the if-statement
 itself defines on what status register bit it should branch on::
 
 	if_XX  <statements>  [else  <statements> ]
@@ -826,7 +826,7 @@ It can also be one of the four aliases that are easier to read: ``if_z``, ``if_n
 .. caution::
     These special ``if_XX`` branching statements are only useful in certain specific situations where you are *certain*
     that the status register (still) contains the correct status bits.
-    This is not always the case after a fuction call or other operations!
+    This is not always the case after a function call or other operations!
     If in doubt, check the generated assembly code!
 
 

--- a/docs/source/syntaxreference.rst
+++ b/docs/source/syntaxreference.rst
@@ -119,7 +119,7 @@ Directives
 	Sets special compiler options.
 
     - ``enable_floats`` (module level) tells the compiler
-      to deal with floating point numbers (by using various subroutines from the Commodore-64 kernal).
+      to deal with floating point numbers (by using various subroutines from the Commodore 64 kernal).
       Otherwise, floating point support is not enabled. Normally you don't have to use this yourself as
       importing the ``floats`` library is required anyway and that will enable it for you automatically.
     - ``no_sysinit`` (module level) which cause the resulting program to *not* include
@@ -662,7 +662,7 @@ flag such as Carry (Pc).
     The 'virtual' 16-bit registers from the Commander X16 can also be specified as ``R0`` .. ``R15`` .
     This means you don't have to set them up manually before calling a subroutine that takes
     one or more parameters in those 'registers'. You can just list the arguments directly.
-    *This also works on the Commodore-64!*  (however they are not as efficient there because they're not in zeropage)
+    *This also works on the Commodore 64!*  (however they are not as efficient there because they're not in zeropage)
     In prog8 and assembly code these 'registers' are directly accessible too via
     ``cx16.r0`` .. ``cx16.r15``  (these are memory mapped uword values),
     ``cx16.r0s`` .. ``cx16.r15s``  (these are memory mapped word values),

--- a/docs/source/syntaxreference.rst
+++ b/docs/source/syntaxreference.rst
@@ -86,7 +86,7 @@ Directives
     The other options need those locations for other things so those virtual registers have
     to be put into memory elsewhere (outside of the zeropage). Trying to use them as zero page
     variables or pointers etc. will be a lot slower in those cases!
-    On the CommanderX16 the registers are always in zeropage. On other targets, for now, they
+    On the Commander X16 the registers are always in zeropage. On other targets, for now, they
     are always outside of the zeropage.
 
 .. data:: %zpreserved <fromaddress>,<toaddress>

--- a/docs/source/targetsystem.rst
+++ b/docs/source/targetsystem.rst
@@ -64,7 +64,7 @@ reserved address    in use for
 ==================  =======================
 
 The actual machine will often have many other special addresses as well,
-For example, the Commodore-64 has:
+For example, the Commodore 64 has:
 
 - ROMs installed in the machine: BASIC, kernal and character roms. Occupying ``$a000``--``$bfff`` and ``$e000``--``$ffff``.
 - memory-mapped I/O registers, for the video and sound chips, and the CIA's. Occupying ``$d000``--``$dfff``.

--- a/docs/source/targetsystem.rst
+++ b/docs/source/targetsystem.rst
@@ -80,7 +80,7 @@ ZeroPage ("ZP")
 
 The ZeroPage memory block ``$02``--``$ff`` can be regarded as 254 CPU 'registers', because
 they take less clock cycles to access and need fewer instruction bytes than accessing other memory locations outside of the ZP.
-Theoretically they can all be used in a program, with the follwoing limitations:
+Theoretically they can all be used in a program, with the following limitations:
 
 - several addresses (``$02``, ``$03``, ``$fb - $fc``, ``$fd - $fe``) are reserved for internal use
 - most other addresses will already be in use by the machine's operating system or kernal,
@@ -100,7 +100,7 @@ There's a global program directive to specify the way the compiler
 treats the ZP for the program. The default is to be reasonably restrictive to use the
 part of the ZP that is not used by the C64's kernal routines.
 It's possible to claim the whole ZP as well (by disabling the operating system or kernal).
-If you want, it's also possible to be more restricive and stay clear of the addresses used by BASIC routines too.
+If you want, it's also possible to be more restrictive and stay clear of the addresses used by BASIC routines too.
 This allows the program to exit cleanly back to a BASIC ready prompt - something that is not possible in the other modes.
 
 
@@ -163,5 +163,5 @@ The Commander X16 provides two additional routines that should be used *in your 
 
     cx16.push_vera_context()
     ; ... do your work that uses vera here...
-    cx15.pop_vera_context()
+    cx16.pop_vera_context()
 

--- a/docs/source/technical.rst
+++ b/docs/source/technical.rst
@@ -7,7 +7,7 @@ All variables are static in memory
 
 All variables are allocated statically, there is no concept of dynamic heap or stack frames.
 Essentially all variables are global (but scoped) and can be accessed and modified anywhere,
-but care should be taken ofcourse to avoid unexpected side effects.
+but care should be taken of course to avoid unexpected side effects.
 
 Especially when you're dealing with interrupts or re-entrant routines: don't modify variables
 that you not own or else you will break stuff.

--- a/docs/source/technical.rst
+++ b/docs/source/technical.rst
@@ -42,7 +42,7 @@ Calling a subroutine requires three steps:
 
 #. preparing the arguments (if any) and passing them to the routine
 #. calling the routine
-#. preparig the return value (if any) and returning that from the call.
+#. preparing the return value (if any) and returning that from the call.
 
 
 Calling the routine is just a simple JSR instruction, but the other two work like this:
@@ -83,7 +83,7 @@ Some builtin functions have a fully custom implementation.
 
 
 The compiler will warn about routines that are called and that return a value, if you're not
-doing something with that returnvalue. This can be on purpuse if you're simply not interested in it.
+doing something with that returnvalue. This can be on purpose if you're simply not interested in it.
 Use the ``void`` keyword in front of the subroutine call to get rid of the warning in that case.
 
 
@@ -138,7 +138,7 @@ Some notes and references into the compiler's source code modules:
    Most notably, node type information is now baked in. (``codeCore`` module)
 #. An *Intermediate Representation* has been defined that is generated from the intermediate AST. This IR
    is more or less a machine code language for a virtual machine - and indeed this is what the built-in
-   prog8 VM will execute if you use the 'virtual' compilaton target and use ``-emu`` to launch the VM.
+   prog8 VM will execute if you use the 'virtual' compilation target and use ``-emu`` to launch the VM.
    (``intermediate`` and ``codeGenIntermediate`` modules, and ``virtualmachine`` module for the VM related stuff)
 #. Currently the 6502 ASM code generator still works directly on the *Compiler AST*. A future version
    should replace this by working on the IR code, and should be much smaller and simpler.


### PR DESCRIPTION
Things to consider which don't need answering:

* "sometimes an actual value conversion is done to convert it into the targe type" - targe?
* Petscii, PETSCII or petscii?
* BASIC or Basic?
* kernal or KERNAL?
* zeropage, Zeropage, ZeroPage or Zero page?
* C64 or C-64?
* "Vice" being written for VICE I assume is a stylistic choice. The BBC also does this.
* I haven't thought about the to-do page too deeply due to its temporary nature.

I have grouped together a few changes into separate commits so they can easily be reverted if you prefer.