### PR TITLE
Feature/read cursor position

### DIFF
--- a/compiler/res/prog8lib/atari/textio.p8
+++ b/compiler/res/prog8lib/atari/textio.p8
@@ -24,12 +24,24 @@ sub spc() {
     txt.chrout(' ')
 }
 
-asmsub column(ubyte col @A) clobbers(A, X, Y) {
+const uword COLCRS = 85
+const uword ROWCRS = 84
+sub column(ubyte col) {
     ; ---- set the cursor on the given column (starting with 0) on the current line
-    ;      TODO
-    %asm {{
-        rts
-    }}
+    pokew(COLCRS, col as uword)
+}
+
+sub get_column() -> ubyte {
+    return peekw(COLCRS) as ubyte
+}
+
+sub row(ubyte rownum) {
+    ; ---- set the cursor on the given row (starting with 0) on the current line
+    @(ROWCRS) = rownum
+}
+
+sub get_row() -> ubyte {
+    return @(ROWCRS)
 }
 
 asmsub  fill_screen (ubyte character @ A, ubyte color @ Y) clobbers(A)  {
@@ -372,12 +384,14 @@ sub  setcc  (ubyte col, ubyte row, ubyte char, ubyte charcolor)  {
         }}
 }
 
-asmsub  plot  (ubyte col @ Y, ubyte row @ A) {
-	; ---- set cursor at specific position
-	; TODO
-	%asm  {{
-	    rts
-	}}
+sub  plot(ubyte col, ubyte rownum) {
+  column(col)
+  row(rownum)
+}
+
+sub get_cursor(uword colptr, uword rowptr) {
+  @(colptr) = get_column()
+  @(rowptr) = get_row()
 }
 
 asmsub width() clobbers(X,Y) -> ubyte @A {

--- a/compiler/res/prog8lib/c128/textio.p8
+++ b/compiler/res/prog8lib/c128/textio.p8
@@ -623,7 +623,7 @@ asmsub height() clobbers(X, Y) -> ubyte @A {
     }}
 }
 
-asmsub waitkey() -> ubyte @A {
+asmsub waitkey() {
     %asm {{
 -       jsr cbm.GETIN
         beq -

--- a/compiler/res/prog8lib/c128/textio.p8
+++ b/compiler/res/prog8lib/c128/textio.p8
@@ -46,7 +46,7 @@ asmsub get_column() -> ubyte @Y {
     }}
 }
 
-asmsub row(ubyte col @A) clobbers(A, X, Y) {
+asmsub row(ubyte rownum @A) clobbers(A, X, Y) {
     ; ---- set the cursor on the given row (starting with 0) on the current line
     %asm {{
         sec

--- a/compiler/res/prog8lib/c128/textio.p8
+++ b/compiler/res/prog8lib/c128/textio.p8
@@ -623,4 +623,11 @@ asmsub height() clobbers(X, Y) -> ubyte @A {
     }}
 }
 
+asmsub waitkey() -> ubyte @A {
+    %asm {{
+-       jsr cbm.GETIN
+        beq -
+        rts
+    }}
+}
 }

--- a/compiler/res/prog8lib/c128/textio.p8
+++ b/compiler/res/prog8lib/c128/textio.p8
@@ -38,6 +38,45 @@ asmsub column(ubyte col @A) clobbers(A, X, Y) {
     }}
 }
 
+
+asmsub get_column() -> ubyte @Y {
+    %asm {{
+        sec
+        jmp cbm.PLOT
+    }}
+}
+
+asmsub row(ubyte col @A) clobbers(A, X, Y) {
+    ; ---- set the cursor on the given row (starting with 0) on the current line
+    %asm {{
+        sec
+        jsr  cbm.PLOT
+        tax
+        clc
+        jmp  cbm.PLOT
+    }}
+}
+
+asmsub get_row() -> ubyte @X {
+    %asm {{
+        sec
+        jmp cbm.PLOT
+    }}
+}
+
+sub get_cursor(uword colptr, uword rowptr) {
+    %asm {{
+        sec
+        jsr cbm.PLOT
+        tya
+        ldy #$00
+        sta (colptr),y
+        txa
+        sta (rowptr),y
+    }}
+}
+
+
 asmsub  fill_screen (ubyte char @ A, ubyte color @ Y) clobbers(A)  {
 	; ---- fill the character screen with the given fill character and character color.
 	;      (assumes screen and color matrix are at their default addresses)

--- a/compiler/res/prog8lib/c64/textio.p8
+++ b/compiler/res/prog8lib/c64/textio.p8
@@ -47,7 +47,7 @@ asmsub get_column() -> ubyte @Y {
     }}
 }
 
-asmsub row(ubyte col @A) clobbers(A, X, Y) {
+asmsub row(ubyte rownum @A) clobbers(A, X, Y) {
     ; ---- set the cursor on the given row (starting with 0) on the current line
     %asm {{
         sec

--- a/compiler/res/prog8lib/c64/textio.p8
+++ b/compiler/res/prog8lib/c64/textio.p8
@@ -39,6 +39,45 @@ asmsub column(ubyte col @A) clobbers(A, X, Y) {
     }}
 }
 
+
+asmsub get_column() -> ubyte @Y {
+    %asm {{
+        sec
+        jmp cbm.PLOT
+    }}
+}
+
+asmsub row(ubyte col @A) clobbers(A, X, Y) {
+    ; ---- set the cursor on the given row (starting with 0) on the current line
+    %asm {{
+        sec
+        jsr  cbm.PLOT
+        tax
+        clc
+        jmp  cbm.PLOT
+    }}
+}
+
+asmsub get_row() -> ubyte @X {
+    %asm {{
+        sec
+        jmp cbm.PLOT
+    }}
+}
+
+sub get_cursor(uword colptr, uword rowptr) {
+    %asm {{
+        sec
+        jsr cbm.PLOT
+        tya
+        ldy #$00
+        sta (colptr),y
+        txa
+        sta (rowptr),y
+    }}
+}
+
+
 asmsub  fill_screen (ubyte character @ A, ubyte color @ Y) clobbers(A)  {
 	; ---- fill the character screen with the given fill character and character color.
 	;      (assumes screen and color matrix are at their default addresses)

--- a/compiler/res/prog8lib/c64/textio.p8
+++ b/compiler/res/prog8lib/c64/textio.p8
@@ -622,7 +622,7 @@ asmsub height() clobbers(X, Y) -> ubyte @A {
     }}
 }
 
-asmsub waitkey() -> ubyte @A {
+asmsub waitkey() {
     %asm {{
 -       jsr cbm.GETIN
         beq -

--- a/compiler/res/prog8lib/c64/textio.p8
+++ b/compiler/res/prog8lib/c64/textio.p8
@@ -622,4 +622,11 @@ asmsub height() clobbers(X, Y) -> ubyte @A {
     }}
 }
 
+asmsub waitkey() -> ubyte @A {
+    %asm {{
+-       jsr cbm.GETIN
+        beq -
+        rts
+    }}
+}
 }

--- a/compiler/res/prog8lib/cx16/textio.p8
+++ b/compiler/res/prog8lib/cx16/textio.p8
@@ -42,6 +42,43 @@ asmsub column(ubyte col @A) clobbers(A, X, Y) {
     }}
 }
 
+asmsub get_column() -> ubyte @Y {
+    %asm {{
+        sec
+        jmp cbm.PLOT
+    }}
+}
+
+asmsub row(ubyte col @A) clobbers(A, X, Y) {
+    ; ---- set the cursor on the given row (starting with 0) on the current line
+    %asm {{
+        sec
+        jsr  cbm.PLOT
+        tax
+        clc
+        jmp  cbm.PLOT
+    }}
+}
+
+asmsub get_row() -> ubyte @X {
+    %asm {{
+        sec
+        jmp cbm.PLOT
+    }}
+}
+
+sub get_cursor(uword colptr, uword rowptr) {
+    %asm {{
+        sec
+        jsr cbm.PLOT
+        tya
+        ldy #$00
+        sta (colptr),y
+        txa
+        sta (rowptr),y
+    }}
+}
+
 asmsub  fill_screen (ubyte character @ A, ubyte color @ Y) clobbers(A, X)  {
 	; ---- fill the character screen with the given fill character and character color.
 	%asm {{

--- a/compiler/res/prog8lib/cx16/textio.p8
+++ b/compiler/res/prog8lib/cx16/textio.p8
@@ -793,4 +793,11 @@ asmsub height() clobbers(X, Y) -> ubyte @A {
     }}
 }
 
+asmsub waitkey() -> ubyte @A {
+    %asm {{
+-       jsr cbm.GETIN
+        beq -
+        rts
+    }}
+}
 }

--- a/compiler/res/prog8lib/cx16/textio.p8
+++ b/compiler/res/prog8lib/cx16/textio.p8
@@ -49,7 +49,7 @@ asmsub get_column() -> ubyte @Y {
     }}
 }
 
-asmsub row(ubyte col @A) clobbers(A, X, Y) {
+asmsub row(ubyte rownum @A) clobbers(A, X, Y) {
     ; ---- set the cursor on the given row (starting with 0) on the current line
     %asm {{
         sec

--- a/compiler/res/prog8lib/cx16/textio.p8
+++ b/compiler/res/prog8lib/cx16/textio.p8
@@ -793,7 +793,7 @@ asmsub height() clobbers(X, Y) -> ubyte @A {
     }}
 }
 
-asmsub waitkey() -> ubyte @A {
+asmsub waitkey() {
     %asm {{
 -       jsr cbm.GETIN
         beq -

--- a/compiler/res/prog8lib/pet32/textio.p8
+++ b/compiler/res/prog8lib/pet32/textio.p8
@@ -28,6 +28,45 @@ sub spc() {
 }
 
 
+
+asmsub get_column() -> ubyte @Y {
+    %asm {{
+        sec
+        jmp cbm.PLOT
+    }}
+}
+
+asmsub row(ubyte col @A) clobbers(A, X, Y) {
+    ; ---- set the cursor on the given row (starting with 0) on the current line
+    %asm {{
+        sec
+        jsr  cbm.PLOT
+        tax
+        clc
+        jmp  cbm.PLOT
+    }}
+}
+
+asmsub get_row() -> ubyte @X {
+    %asm {{
+        sec
+        jmp cbm.PLOT
+    }}
+}
+
+sub get_cursor(uword colptr, uword rowptr) {
+    %asm {{
+        sec
+        jsr cbm.PLOT
+        tya
+        ldy #$00
+        sta (colptr),y
+        txa
+        sta (rowptr),y
+    }}
+}
+
+
 asmsub  fill_screen (ubyte character @ A, ubyte color @ Y) clobbers(A)  {
 	; ---- fill the character screen with the given fill character. color is ignored on PET
 	%asm {{

--- a/compiler/res/prog8lib/pet32/textio.p8
+++ b/compiler/res/prog8lib/pet32/textio.p8
@@ -36,7 +36,7 @@ asmsub get_column() -> ubyte @Y {
     }}
 }
 
-asmsub row(ubyte col @A) clobbers(A, X, Y) {
+asmsub row(ubyte rownum @A) clobbers(A, X, Y) {
     ; ---- set the cursor on the given row (starting with 0) on the current line
     %asm {{
         sec

--- a/compiler/res/prog8lib/pet32/textio.p8
+++ b/compiler/res/prog8lib/pet32/textio.p8
@@ -492,4 +492,11 @@ asmsub height() clobbers(X, Y) -> ubyte @A {
     }}
 }
 
+asmsub waitkey() -> ubyte @A {
+    %asm {{
+-       jsr cbm.GETIN
+        beq -
+        rts
+    }}
+}
 }

--- a/compiler/res/prog8lib/pet32/textio.p8
+++ b/compiler/res/prog8lib/pet32/textio.p8
@@ -492,7 +492,7 @@ asmsub height() clobbers(X, Y) -> ubyte @A {
     }}
 }
 
-asmsub waitkey() -> ubyte @A {
+asmsub waitkey() {
     %asm {{
 -       jsr cbm.GETIN
         beq -


### PR DESCRIPTION
Add ability to read cursor position (both coords at once or one at a time), as well as set row and column indpendently.
Also implements plot() for atari target and waitkey() for the Commodore target.