### PR TITLE
fixed a glitch in the prog8/vtui example

### DIFF
--- a/examples/cx16/vtui/testvtui.p8
+++ b/examples/cx16/vtui/testvtui.p8
@@ -8,13 +8,16 @@
 main {
     sub start() {
         vtui.initialize()
-        store_logo()
+        store_logo()            ; capture logo before boxes are drawn
 
         txt.lowercase()
         vtui.screen_set(0)
         vtui.clr_scr('%', $50)
         vtui.gotoxy(5,5)
         vtui.fill_box(':', 70, 50, $c6)
+
+        store_where_logo_was()  ; after vtui draws boxes, initialize replacement screen values as logo moves
+
         vtui.gotoxy(10,10)
         vtui.border(1, 40, 6, $47)
         vtui.gotoxy(12,12)
@@ -45,6 +48,9 @@ main {
     sub store_logo() {
         vtui.gotoxy(0, 0)
         vtui.save_rect($80, 1, $0000, 7, 7)
+    }
+
+    sub store_where_logo_was() {
         vtui.gotoxy(0, 0)
         vtui.save_rect($80, 1, $0100, 7, 7)
     }


### PR DESCRIPTION
When the program starts, before the screen is modified, save_rec is called to capture the cx16 logo.

The fix was to not do the second call to save_rec until after vtui is used to draw the boxes on the screen.

Before the this fix, the initial replacement issue was of the logo and not the portion of the screen originally modified by vtui.

Before:

![image](https://github.com/irmen/prog8/assets/69679854/e0283b55-8d2f-474d-a5af-815b1145a1e4)

After:

(note: ignore the difference in background, (i.e., the `%` and `:` filling the screen) - this is part of the original example in the repo)

![image](https://github.com/irmen/prog8/assets/69679854/52444685-aebd-4694-9c0c-ee7dcc41e8b0)
