### PR TITLE
Add Syntax Higlighting for `nano`

### DIFF
--- a/syntax-files/nano/prog8.nanorc
+++ b/syntax-files/nano/prog8.nanorc
@@ -1,0 +1,66 @@
+## Prog8 syntax
+
+## Created by Adiee5
+## If issues encountered, make an issue on prog8 github page and ping @Adiee5
+## Licensed under GPL v3
+
+syntax prog8 "\.p8$"
+comment ";"
+
+# Index thing and Array literals
+##color teal "\[[^]]*\]" ## nword
+color teal "\]"
+color teal "\["
+
+# Scope Parents
+color lightblack "[[:alpha:]][[:alnum:]_]*\."
+
+# function
+color brightyellow "[[:alpha:]][[:alnum:]_]*[[:blank:]]*\("
+
+# Key Words
+color lightgreen "\<(true|if_cs|if_eq|if_mi|if_vs|if_z|if_neg)\>"
+color lightred "\<(false|if_cc|if_ne|if_pl|if_vc|if_nz|if_pos)\>"
+color red "\<if(\>|_)"
+color red "\<(sub|(inline[[:space:]]+)?asmsub|romsub|else|void|not|and|x?or|for|in|(down)?to|return|while|repeat|break|continue|step|goto|when|as|const|do|until|unroll)\>"
+
+# Labels
+color sky "^[[:alpha:]][[:alnum:]_]*:"
+
+# Data Types
+color crimson "\<(u?byte|u?word|str|bool|float)\>"
+
+# Brackets
+color yellow "[()]"
+
+# @
+color brightmagenta "@[[:blank:]]*[[:alnum:]_]*"
+
+# &
+color brick "&"
+
+# Arrows
+color lagoon "->"
+
+# Encoding
+color cyan "[[:alnum:]_]+:["']"
+
+# char literal
+color brightcyan "'([^\\]|\\([^ux]|u[0-9A-Fa-f]{4}|x[[:alnum:]]{2}))'"
+
+# %asm handling
+color normal start="%[Aa][Ss][Mm]" end="}}"
+color magenta "%[Aa][Sm][Mm]"
+
+# Directives
+color magenta "^[[:space:]]*%[[:alpha:]]+"
+
+# Strings
+color brightblue ""([^"]|\\")*""
+
+# Comments
+color green ";.*"
+color green start="/\*" end="\*/"
+
+# Trailing Whitespace
+color ,green "[[:space:]]+$"

--- a/syntax-files/nano/readme.md
+++ b/syntax-files/nano/readme.md
@@ -1,0 +1,14 @@
+# Syntax Highlight for **nano**
+
+ Contributed to prog8 by Adiee5
+
+In order to use this. you need to download the `prog8.nanorc` file. You can download it wherever you want to, 
+preferably at `~/.config/nano/`. Then, you need to include this file into your `nanorc` file 
+(it's at `~/.nanorc` or `~/.config/nano/nanorc`, alternatively, you could edit the global `/etc/nanorc` file).
+All you neet to do is to add this to your config file:
+
+```nanorc
+## prog8 syntax file:
+ include "/path/to/your/prog8.nanorc"
+```
+After that, enjoy the syntax highlighting!


### PR DESCRIPTION
This Adds the syntax highlighting of prog8 for nano! here's a preview:
![2024-02-08-004046_1052x952_scrot](https://github.com/irmen/prog8/assets/58359866/38a4c85a-4200-4a36-a7f9-def7b0ed1089)
