### PR TITLE
Add diskio.status_code() function

### DIFF
--- a/compiler/res/prog8lib/cx16/diskio.p8
+++ b/compiler/res/prog8lib/cx16/diskio.p8
@@ -543,6 +543,10 @@ io_error:
         list_filename[1] = cbm.CHRIN()
         list_filename[2] = 0
 
+        while cbm.READST()==0 {
+            cbm.CHRIN()
+        }
+
         cbm.CLRCHN()        ; restore default i/o devices
         cbm.CLOSE(15)
         return conv.str2ubyte(list_filename)

--- a/compiler/res/prog8lib/cx16/diskio.p8
+++ b/compiler/res/prog8lib/cx16/diskio.p8
@@ -525,6 +525,35 @@ io_error:
         goto done
     }
 
+    ; similar to above, but instead of fetching the entire string, it only fetches the status code and returns it as ubyte
+    ; in case of IO error, returns 255 (CMDR-DOS itself is physically unable to return such a value)
+    sub status_code() -> ubyte {
+        if cbm.READST()==128 {
+            return 255
+        }
+
+        cbm.SETNAM(0, list_filename)
+        cbm.SETLFS(15, drivenumber, 15)
+        void cbm.OPEN()          ; open 15,8,15
+        if_cs
+            goto io_error
+        void cbm.CHKIN(15)        ; use #15 as input channel
+
+        list_filename[0] = cbm.CHRIN()
+        list_filename[1] = cbm.CHRIN()
+        list_filename[2] = 0
+
+        cbm.CLRCHN()        ; restore default i/o devices
+        cbm.CLOSE(15)
+        return conv.str2ubyte(list_filename)
+
+io_error:
+        cbm.CLRCHN()
+        cbm.CLOSE(15)
+        return 255
+    }
+
+
 
     ; saves a block of memory to disk, including the default 2 byte prg header.
     sub save(uword filenameptr, uword startaddress, uword savesize) -> bool {


### PR DESCRIPTION
This PR adds to diskio a function, that reads the DOS status, but instead of returning string, it returns an ubyte, that corresponds to an error code usually displayed with DOS status messages