### PR TITLE
fix: tweak divmod() doc 

### DIFF
--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -830,7 +830,7 @@ sqrt (w)
 
 divmod (dividend, divisor, quotient, remainder)
     Performs division only once and returns both quotient and remainder in a single call, where using '/' and '%' separately
-    would perform two separate division operations.
+    would perform the division operation twice.
     All values are ubytes or all are uwords.
     The last two arguments must be ubyte variables to receive the division and remainder results, respectively.
 

--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -832,7 +832,7 @@ divmod (dividend, divisor, quotient, remainder)
     Performs division only once and returns both quotient and remainder in a single call, where using '/' and '%' separately
     would perform the division operation twice.
     All values are ubytes or all are uwords.
-    The last two arguments must be ubyte variables to receive the division and remainder results, respectively.
+    The last two arguments must be ubyte variables to receive the quotient and remainder results, respectively.
 
 
 Array operations

--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -828,8 +828,9 @@ sqrt (w)
     Supports unsigned integer (result is ubyte) and floating point numbers.
     To do the reverse - squaring a number - just write ``x*x``.
 
-divmod (number, divident, division, remainder)
-    Performs division and remainder calculation in a single call. This is faster than using separate '/' and '%' calculations.
+divmod (dividend, divisor, quotient, remainder)
+    Performs division only once and returns both quotient and remainder in a single call, where using '/' and '%' separately
+    would perform two separate division operations.
     All values are ubytes or all are uwords.
     The last two arguments must be ubyte variables to receive the division and remainder results, respectively.
 


### PR DESCRIPTION
adjust naming on divmod parameters to match standard mathematical terminology; clarify description