### PR TITLE
Add  24-bit integer-to-float routine and floating-point jiffy clock reader

### DIFF
--- a/compiler/res/prog8lib/c64/floats.p8
+++ b/compiler/res/prog8lib/c64/floats.p8
@@ -36,7 +36,7 @@ romsub $b1bf = AYINT() clobbers(A,X,Y)          ; fac1-> signed word in 100-101 
 ; there is also floats.GIVUAYFAY - unsigned word in A/Y (lo/hi) to fac1
 ; there is also floats.FREADS32  that reads from 98-101 ($62-$65) MSB FIRST
 ; there is also floats.FREADUS32  that reads from 98-101 ($62-$65) MSB FIRST
-; there is also floats.FREADS24AXY  that reads signed int24 into fac1 from A/X/Y (lo/mid/hi bytes)
+; there is also floats.FREAD{S,U}24AXY  that read (un)signed int24 into fac1 from A/X/Y (lo/mid/hi bytes)
 romsub $b391 = GIVAYF(ubyte lo @ Y, ubyte hi @ A) clobbers(A,X,Y)
 
 romsub $b3a2 = FREADUY(ubyte value @ Y) clobbers(A,X,Y)     ; 8 bit unsigned Y -> float in fac1
@@ -121,11 +121,28 @@ asmsub  FREADS24AXY  (ubyte lo @ A, ubyte mid @ X, ubyte hi @ Y) clobbers(A,X,Y)
 asmsub FREADU24AXY(ubyte lo @ A, ubyte mid @ X, ubyte hi @ Y) clobbers(A, X, Y) -> float @FAC1 {
         %asm{{
                  FAC = $61
-                 sta FAC+3
-                 stx FAC+2
                  sty FAC+1
-                 lda #$98
-                 sta FAC
+                 stx FAC+2
+                 sta FAC+3
+
+                 cpy #$00
+                 bne +
+                 cpx #$00
+                 bne +
+                 cmp #$00
+                 beq ++
+
+              +  ldx #$98
+                 bit FAC+1
+                 bmi +
+
+              -  dex
+                 asl FAC+3
+                 rol FAC+2
+                 rol FAC+1
+                 bpl -
+
+              +  stx FAC
                  lda #$00
                  sta FAC+4
                  sta FAC+5

--- a/compiler/res/prog8lib/c64/floats.p8
+++ b/compiler/res/prog8lib/c64/floats.p8
@@ -104,7 +104,6 @@ asmsub  FREADUS32  () clobbers(A,X,Y)  {
 
 asmsub  FREADS24AXY  (ubyte lo @ A, ubyte mid @ X, ubyte hi @ Y) clobbers(A,X,Y)  {
 	; ---- fac1 = signed int24 (A/X/Y contain lo/mid/hi bytes)
-	;      note: there is no FREADU24AXY (unsigned), use FREADUS32 instead.
 	%asm {{
 		sty  $62
 		stx  $63
@@ -117,6 +116,21 @@ asmsub  FREADS24AXY  (ubyte lo @ A, ubyte mid @ X, ubyte hi @ Y) clobbers(A,X,Y)
 		ldx  #$98
 		jmp  $bc4f		; internal BASIC routine
 	}}
+}
+
+asmsub FREADU24AXY(ubyte lo @ A, ubyte mid @ X, ubyte hi @ Y) clobbers(A, X, Y) -> float @FAC1 {
+        %asm{{
+                 FAC = $61
+                 sta FAC+3
+                 stx FAC+2
+                 sty FAC+1
+                 lda #$98
+                 sta FAC
+                 lda #$00
+                 sta FAC+4
+                 sta FAC+5
+                 rts
+       }}
 }
 
 asmsub  GIVUAYFAY  (uword value @ AY) clobbers(A,X,Y)  {
@@ -177,6 +191,13 @@ asmsub normalize(float value @FAC1) -> float @ FAC1 {
     }}
 }
 
+; get the jiffy clock as a float
+asmsub time() -> float @ FAC1 {
+    %asm {{
+        jsr cbm.RDTIM
+        jmp floats.FREADU24AXY
+    }}
+}
 
 %asminclude "library:c64/floats.asm"
 %asminclude "library:c64/floats_funcs.asm"

--- a/compiler/res/prog8lib/cx16/floats.p8
+++ b/compiler/res/prog8lib/cx16/floats.p8
@@ -171,48 +171,6 @@ _msg    .text 13,"?rom 47+ required for val1",13,0
     }}
 }
 
-; read A/X/Y as a 24-bit unsigned integer, lsb in A, msb in Y
-; useful in conjunction with RDTIM()
-asmsub FREADU24AXY() -> float @FAC1 {
-        %asm{{
-                cmp #$00
-                bne u24axy_nonzero
-                cpx #$00
-                bne u24axy_nonzero
-                cpy #$00
-                bne u24axy_nonzero
-
-                lda #$00
-                sta FAC
-                sta FAC+1
-                sta FAC+2
-                sta FAC+3
-                sta FAC+4
-                sta FAC+5
-                beq u24axy_done
-
-u24axy_nonzero: sta FAC+3
-                stx FAC+2
-                sty FAC+1
-                ldx #$98
-                sta FAC
-                bit FAC+1
-                bmi u24axy_done
-
-  u24axy_shift: dex
-                asl FAC+3
-                rol FAC+2
-                rol FAC+1
-                bpl u24axy_shift
-
-   u24axy_done: stx FAC
-                lda #$00
-                sta FAC+4
-                sta FAC+5
-                rts
-        }}
-}
-
 &uword AYINT_facmo = $c6      ; $c6/$c7 contain result of AYINT   (See "basic.sym" kernal symbol file)
 
 sub rnd() -> float {

--- a/compiler/res/prog8lib/cx16/floats.p8
+++ b/compiler/res/prog8lib/cx16/floats.p8
@@ -90,6 +90,20 @@ asmsub  FREADSA  (byte value @A) clobbers(A,X,Y) {
     }}
 }
 
+asmsub FREADU24AXY(ubyte lo @ A, ubyte mid @ X, ubyte hi @ Y) clobbers(A, X, Y) -> float @FAC1 {
+        %asm{{
+                 FAC = $c3
+                 sta FAC+3
+                 stx FAC+2
+                 sty FAC+1
+                 lda #$98
+                 sta FAC
+                 stz FAC+4
+                 stz FAC+5
+                 rts
+       }}
+}
+
 asmsub  GIVUAYFAY  (uword value @ AY) clobbers(A,X,Y)  {
 	; ---- unsigned 16 bit word in A/Y (lo/hi) to fac1
 	%asm {{
@@ -157,6 +171,47 @@ _msg    .text 13,"?rom 47+ required for val1",13,0
     }}
 }
 
+; read A/X/Y as a 24-bit unsigned integer, lsb in A, msb in Y
+; useful in conjunction with RDTIM()
+asmsub FREADU24AXY() -> float @FAC1 {
+        %asm{{
+                cmp #$00
+                bne u24axy_nonzero
+                cpx #$00
+                bne u24axy_nonzero
+                cpy #$00
+                bne u24axy_nonzero
+
+                lda #$00
+                sta FAC
+                sta FAC+1
+                sta FAC+2
+                sta FAC+3
+                sta FAC+4
+                sta FAC+5
+                beq u24axy_done
+
+u24axy_nonzero: sta FAC+3
+                stx FAC+2
+                sty FAC+1
+                ldx #$98
+                sta FAC
+                bit FAC+1
+                bmi u24axy_done
+
+  u24axy_shift: dex
+                asl FAC+3
+                rol FAC+2
+                rol FAC+1
+                bpl u24axy_shift
+
+   u24axy_done: stx FAC
+                lda #$00
+                sta FAC+4
+                sta FAC+5
+                rts
+        }}
+}
 
 &uword AYINT_facmo = $c6      ; $c6/$c7 contain result of AYINT   (See "basic.sym" kernal symbol file)
 
@@ -170,6 +225,14 @@ sub rnd() -> float {
 asmsub normalize(float value @FAC1) -> float @ FAC1 {
     %asm {{
         jmp  floats.NORMAL
+    }}
+}
+
+; get the jiffy clock as a float
+asmsub time() -> float @ FAC1 {
+    %asm {{
+        jsr cbm.RDTIM
+        jmp floats.FREADU24AXY
     }}
 }
 

--- a/compiler/res/prog8lib/cx16/floats.p8
+++ b/compiler/res/prog8lib/cx16/floats.p8
@@ -92,12 +92,29 @@ asmsub  FREADSA  (byte value @A) clobbers(A,X,Y) {
 
 asmsub FREADU24AXY(ubyte lo @ A, ubyte mid @ X, ubyte hi @ Y) clobbers(A, X, Y) -> float @FAC1 {
         %asm{{
-                 FAC = $c3
-                 sta FAC+3
-                 stx FAC+2
+                 FAC = $C3
                  sty FAC+1
-                 lda #$98
-                 sta FAC
+                 stx FAC+2
+                 sta FAC+3
+
+                 cpy #$00
+                 bne +
+                 cpx #$00
+                 bne +
+                 cmp #$00
+                 beq ++
+
+              +  ldx #$98
+                 bit FAC+1
+                 bmi +
+
+              -  dex
+                 asl FAC+3
+                 rol FAC+2
+                 rol FAC+1
+                 bpl -
+
+               + stx FAC
                  stz FAC+4
                  stz FAC+5
                  rts


### PR DESCRIPTION
This adds two new routines to the floats library on the c64 and cx16 targets:

*  FREADU24AXY (companion to the c64's FREADS24AXY for signed values) to convert an unsigned 24-bit integer from A/X/Y (A=lsb, Y=msb) to a floating-point value in the primary floating-point accumulator.
* time(), which uses the above routine to return the current value of the jiffy clock as a float