### PR TITLE
Always call CLRCHN before possibly-redundant CHKIN/CHKOUT calls

### DIFF
--- a/compiler/res/prog8lib/shared_cbm_diskio.p8
+++ b/compiler/res/prog8lib/shared_cbm_diskio.p8
@@ -20,7 +20,7 @@ diskio {
 
     sub reset_write_channel() {
         void cbm.CLRCHN()
-        cbm.CHKOUT(WRITE_IO_CHANNEL)
+        void cbm.CHKOUT(WRITE_IO_CHANNEL)
     }
 
     sub directory() -> bool {

--- a/compiler/res/prog8lib/shared_cbm_diskio.p8
+++ b/compiler/res/prog8lib/shared_cbm_diskio.p8
@@ -14,10 +14,12 @@ diskio {
     ubyte @shared drivenumber = 8           ; user programs can set this to the drive number they want to load/save to!
 
     sub reset_read_channel() {
+        void cbm.CLRCHN()
         void cbm.CHKIN(READ_IO_CHANNEL)
     }
 
     sub reset_write_channel() {
+        void cbm.CLRCHN()
         cbm.CHKOUT(WRITE_IO_CHANNEL)
     }
 


### PR DESCRIPTION
Fixes #156.