### PR TITLE
Improve romability of low-level libs

### DIFF
--- a/compiler/res/prog8lib/c128/syslib.p8
+++ b/compiler/res/prog8lib/c128/syslib.p8
@@ -459,10 +459,12 @@ sys {
             lda  P8ZP_SCRATCH_W2+1
             sta  save_SCRATCH_ZPWORD2+1
             rts
-save_SCRATCH_ZPB1	.byte  0
-save_SCRATCH_ZPREG	.byte  0
-save_SCRATCH_ZPWORD1	.word  0
-save_SCRATCH_ZPWORD2	.word  0
+            .section BSS
+save_SCRATCH_ZPB1	.byte  ?
+save_SCRATCH_ZPREG	.byte  ?
+save_SCRATCH_ZPWORD1	.word  ?
+save_SCRATCH_ZPWORD2	.word  ?
+            .send BSS
             ; !notreached!
         }}
     }
@@ -488,8 +490,8 @@ save_SCRATCH_ZPWORD2	.word  0
 asmsub  set_irq(uword handler @AY) clobbers(A)  {
 	%asm {{
 		sei
-        sta  _modified+1
-        sty  _modified+2
+        sta  _vector
+        sty  _vector+1
 		lda  #<_irq_handler
 		sta  cbm.CINV
 		lda  #>_irq_handler
@@ -499,8 +501,8 @@ asmsub  set_irq(uword handler @AY) clobbers(A)  {
 _irq_handler
         jsr  sys.save_prog8_internals
         cld
-_modified
-        jsr  $ffff                      ; modified
+
+        jsr  _run_custom
         pha
         jsr  sys.restore_prog8_internals
         pla
@@ -515,6 +517,12 @@ _modified
 		tax
 		pla
 		rti
+_run_custom
+		jmp  (_vector)
+		.section BSS
+_vector	.word ?
+		.send BSS
+        ; !notreached!
 		}}
 }
 
@@ -537,8 +545,8 @@ asmsub  restore_irq() clobbers(A) {
 asmsub  set_rasterirq(uword handler @AY, uword rasterpos @R0) clobbers(A) {
 	%asm {{
         sei
-        sta  _modified+1
-        sty  _modified+2
+        sta  _vector
+        sty  _vector+1
         lda  cx16.r0
         ldy  cx16.r0+1
         jsr  _setup_raster_irq
@@ -552,8 +560,8 @@ asmsub  set_rasterirq(uword handler @AY, uword rasterpos @R0) clobbers(A) {
 _raster_irq_handler
 		jsr  sys.save_prog8_internals
 		cld
-_modified
-        jsr  $ffff              ; modified
+
+        jsr  _run_custom
         pha
 		jsr  sys.restore_prog8_internals
         lda  #$ff
@@ -567,6 +575,12 @@ _modified
 		tax
 		pla
 		rti
+_run_custom
+		jmp  (_vector)
+		.section BSS
+_vector	.word ?
+		.send BSS
+
 
 _setup_raster_irq
 		pha
@@ -1063,10 +1077,11 @@ cx16 {
             dey
             bpl  -
             rts
-
+            .section BSS
     _cx16_vreg_storage
-            .word 0,0,0,0,0,0,0,0
-            .word 0,0,0,0,0,0,0,0
+            .word ?,?,?,?,?,?,?,?
+            .word ?,?,?,?,?,?,?,?
+            .send BSS
             ; !notreached!
         }}
     }
@@ -1131,6 +1146,7 @@ asmsub  init_system_phase2()  {
 
 asmsub  cleanup_at_exit() {
     ; executed when the main subroutine does rts
+    ; TODO: Romable (It's technically an easy fix, but i've decided not to touch it for now)
     %asm {{
         lda  #0
         sta  $ff00          ; default bank 15

--- a/compiler/res/prog8lib/c64/floats.asm
+++ b/compiler/res/prog8lib/c64/floats.asm
@@ -4,8 +4,9 @@ FL_ONE_const	.byte  129     			; 1.0
 FL_ZERO_const	.byte  0,0,0,0,0		; 0.0
 FL_LOG2_const	.byte  $80, $31, $72, $17, $f8	; log(2)
 
-
-floats_temp_var         .byte  0,0,0,0,0        ; temporary storage for a float
+		.section BSS
+floats_temp_var         .byte  ?,?,?,?,?        ; temporary storage for a float
+		.send BSS
 
 ub2float	.proc
 		; -- convert ubyte in SCRATCH_ZPB1 to float at address A/Y
@@ -178,10 +179,10 @@ dec_var_f	.proc
 		jmp  MOVMF
 		.pend
 
-
-fmath_float1	.byte 0,0,0,0,0	; storage for a mflpt5 value
-fmath_float2	.byte 0,0,0,0,0	; storage for a mflpt5 value
-
+		.section BSS
+fmath_float1	.byte ?,?,?,?,?	; storage for a mflpt5 value
+fmath_float2	.byte ?,?,?,?,?	; storage for a mflpt5 value
+		.send BSS
 
 var_fac1_less_f	.proc
 		; -- is the float in FAC1 < the variable AY? Result in A. Clobbers X.

--- a/compiler/res/prog8lib/c64/syslib.p8
+++ b/compiler/res/prog8lib/c64/syslib.p8
@@ -332,6 +332,7 @@ inline asmsub getbanks() -> ubyte @A {
     }}
 }
 
+    ; TODO: Romable
     asmsub x16jsrfar() {
         %asm {{
             ; setup a JSRFAR call (using X16 call convention)
@@ -474,10 +475,12 @@ sys {
             lda  P8ZP_SCRATCH_W2+1
             sta  save_SCRATCH_ZPWORD2+1
             rts
-save_SCRATCH_ZPB1	.byte  0
-save_SCRATCH_ZPREG	.byte  0
-save_SCRATCH_ZPWORD1	.word  0
-save_SCRATCH_ZPWORD2	.word  0
+            .section BSS
+save_SCRATCH_ZPB1	.byte  ?
+save_SCRATCH_ZPREG	.byte  ?
+save_SCRATCH_ZPWORD1	.word  ?
+save_SCRATCH_ZPWORD2	.word  ?
+            .send BSS
             ; !notreached!
         }}
     }
@@ -503,8 +506,8 @@ save_SCRATCH_ZPWORD2	.word  0
 asmsub  set_irq(uword handler @AY) clobbers(A)  {
 	%asm {{
 	    sei
-        sta  _modified+1
-        sty  _modified+2
+        sta  _vector
+        sty  _vector+1
 		lda  #<_irq_handler
 		sta  cbm.CINV
 		lda  #>_irq_handler
@@ -514,8 +517,8 @@ asmsub  set_irq(uword handler @AY) clobbers(A)  {
 _irq_handler
         jsr  sys.save_prog8_internals
         cld
-_modified
-        jsr  $ffff                      ; modified
+
+        jsr  _run_custom
         pha
 		jsr  sys.restore_prog8_internals
 		pla
@@ -530,6 +533,13 @@ _modified
 		tax
 		pla
 		rti
+
+_run_custom
+		jmp  (_vector)
+		.section BSS
+_vector	.word ?
+		.send BSS
+        ; !notreached!
     }}
 }
 
@@ -552,8 +562,8 @@ asmsub  restore_irq() clobbers(A) {
 asmsub  set_rasterirq(uword handler @AY, uword rasterpos @R0) clobbers(A) {
 	%asm {{
 	    sei
-        sta  _modified+1
-        sty  _modified+2
+        sta  _vector
+        sty  _vector+1
         lda  cx16.r0
         ldy  cx16.r0+1
         jsr  _setup_raster_irq
@@ -567,8 +577,8 @@ asmsub  set_rasterirq(uword handler @AY, uword rasterpos @R0) clobbers(A) {
 _raster_irq_handler
 		jsr  sys.save_prog8_internals
 		cld
-_modified
-        jsr  $ffff              ; modified
+
+        jsr  _run_custom
         pha
         jsr  sys.restore_prog8_internals
         lda  #$ff
@@ -582,6 +592,12 @@ _modified
 		tax
 		pla
 		rti
+
+_run_custom
+		jmp  (_vector)
+		.section BSS
+_vector	.word ?
+		.send BSS
 
 _setup_raster_irq
 		pha
@@ -1080,9 +1096,11 @@ cx16 {
             bpl  -
             rts
 
+            .section BSS
     _cx16_vreg_storage
-            .word 0,0,0,0,0,0,0,0
-            .word 0,0,0,0,0,0,0,0
+            .word ?,?,?,?,?,?,?,?
+            .word ?,?,?,?,?,?,?,?
+            .send BSS
             ; !notreached!
         }}
     }
@@ -1157,6 +1175,7 @@ asmsub  init_system_phase2()  {
 
 asmsub  cleanup_at_exit() {
     ; executed when the main subroutine does rts
+    ; TODO: Romable
     %asm {{
         lda  #%00101111
         sta  $00

--- a/compiler/res/prog8lib/conv.p8
+++ b/compiler/res/prog8lib/conv.p8
@@ -6,7 +6,7 @@ conv {
 
 ; ----- number conversions to decimal strings ----
 
-    str  @shared string_out = "????????????????"       ; result buffer for the string conversion routines
+    ubyte[16]  @shared string_out       ; result buffer for the string conversion routines
 
     asmsub str_ub0(ubyte value @A) clobbers(X) -> str @AY {
         ; ---- convert the ubyte in A in decimal string form, with left padding 0s (3 positions total)
@@ -402,7 +402,9 @@ _digit
 +		iny
 		bne  _parse
 		; never reached
-_negative	.byte  0
+		.section BSS
+_negative	.byte  ?
+		.send BSS
         ; !notreached!
 	}}
 }
@@ -699,12 +701,14 @@ ShiftedBcdTab
     .byte $30,$31,$32,$33,$34,$38,$39,$3A,$3B,$3C
     .byte $40,$41,$42,$43,$44,$48,$49,$4A,$4B,$4C
 
-decTenThousands   	.byte  0
-decThousands    	.byte  0
-decHundreds		.byte  0
-decTens			.byte  0
-decOnes   		.byte  0
-			.byte  0		; zero-terminate the decimal output string
+    .section BSS
+decTenThousands   	.byte  ?
+decThousands    	.byte  ?
+decHundreds		.byte  ?
+decTens			.byte  ?
+decOnes   		.byte  ?
+			.byte  ?		; zero-terminate the decimal output string, set to 0 by bss init mechanisms
+    .send BSS
 		; !notreached!
     }}
 }
@@ -756,7 +760,9 @@ asmsub  internal_uword2hex  (uword value @AY) clobbers(A,Y)  {
 		sta  output+2
 		sty  output+3
 		rts
-output		.text  "0000", $00      ; 0-terminated output buffer (to make printing easier)
+		.section BSS
+output		.fill 5      ; 0-terminated output buffer (to make printing easier)
+		.send BSS
 		; !notreached!
 	}}
 }

--- a/compiler/res/prog8lib/cx16/syslib.p8
+++ b/compiler/res/prog8lib/cx16/syslib.p8
@@ -988,10 +988,11 @@ asmsub save_virtual_registers() clobbers(A,Y) {
         dey
         bpl  -
         rts
-
+        .section BSS
 _cx16_vreg_storage
-        .word 0,0,0,0,0,0,0,0
-        .word 0,0,0,0,0,0,0,0
+        .word ?,?,?,?,?,?,?,?
+        .word ?,?,?,?,?,?,?,?
+        .send BSS
         ; !notreached!
     }}
 }
@@ -1030,7 +1031,9 @@ asmsub save_vera_context() clobbers(A) {
         lda  cx16.VERA_ADDR_H
         sta  _vera_storage+6
         rts
-_vera_storage:  .byte 0,0,0,0,0,0,0,0
+        .section BSS
+_vera_storage:  .byte ?,?,?,?,?,?,?,?
+        .send BSS
         ; !notreached!
     }}
 }
@@ -1115,6 +1118,8 @@ asmsub  enable_irq_handlers(bool disable_all_irq_sources @Pc) clobbers(A,Y)  {
     ; to the registered handler for each type.  (Only Vera IRQs supported for now).
     ; The handlers don't need to clear its ISR bit, but have to return 0 or 1 in A,
     ; where 1 means: continue with the system IRQ handler, 0 means: don't call that.
+
+    ; TODO: Romable
 	%asm {{
         php
         sei
@@ -1417,8 +1422,8 @@ asmsub  set_irq(uword handler @AY) clobbers(A)  {
     ; Sets the handler for the VSYNC interrupt, and enable that interrupt.
 	%asm {{
         sei
-        sta  _modified+1
-        sty  _modified+2
+        sta  _vector
+        sty  _vector+1
         lda  #<_irq_handler
         sta  cbm.CINV
         lda  #>_irq_handler
@@ -1431,8 +1436,8 @@ asmsub  set_irq(uword handler @AY) clobbers(A)  {
 _irq_handler
         jsr  sys.save_prog8_internals
         cld
-_modified
-        jsr  $ffff                      ; modified
+
+        jsr  _run_custom
         pha
 		jsr  sys.restore_prog8_internals
 		pla
@@ -1444,6 +1449,12 @@ _modified
 		plx
 		pla
 		rti
+_run_custom
+		jmp  (_vector)
+		.section BSS
+_vector	.word ?
+		.send BSS
+        ; !notreached!
     }}
 }
 
@@ -1460,7 +1471,9 @@ asmsub  restore_irq() clobbers(A) {
 	    sta  cx16.VERA_IEN
 	    cli
 	    rts
-_orig_irqvec    .word  0
+        .section BSS
+_orig_irqvec    .word  ?
+        .send BSS
         ; !notreached!
     }}
 }
@@ -1469,8 +1482,8 @@ asmsub  set_rasterirq(uword handler @AY, uword rasterpos @R0) clobbers(A) {
     ; Sets the handler for the LINE interrupt, and enable (only) that interrupt.
 	%asm {{
             sei
-            sta  _modified+1
-            sty  _modified+2
+            sta  _vector
+            sty  _vector+1
             lda  cx16.r0
             ldy  cx16.r0+1
             lda  cx16.VERA_IEN
@@ -1490,7 +1503,7 @@ asmsub  set_rasterirq(uword handler @AY, uword rasterpos @R0) clobbers(A) {
 _raster_irq_handler
             jsr  sys.save_prog8_internals
             cld
-_modified   jsr  $ffff    ; modified
+            jsr  _run_custom
             jsr  sys.restore_prog8_internals
             ; end irq processing - don't use kernal's irq handling
             lda  #2
@@ -1499,6 +1512,11 @@ _modified   jsr  $ffff    ; modified
             plx
             pla
             rti
+_run_custom
+		    jmp  (_vector)
+		    .section BSS
+_vector	    .word ?
+		    .send BSS
         }}
 }
 
@@ -1784,10 +1802,12 @@ _no_msb_size
             lda  P8ZP_SCRATCH_W2+1
             sta  save_SCRATCH_ZPWORD2+1
             rts
-save_SCRATCH_ZPB1	.byte  0
-save_SCRATCH_ZPREG	.byte  0
-save_SCRATCH_ZPWORD1	.word  0
-save_SCRATCH_ZPWORD2	.word  0
+            .section BSS
+save_SCRATCH_ZPB1	.byte  ?
+save_SCRATCH_ZPREG	.byte  ?
+save_SCRATCH_ZPWORD1	.word  ?
+save_SCRATCH_ZPWORD2	.word  ?
+            .send BSS
             ; !notreached!
         }}
     }
@@ -1968,6 +1988,7 @@ asmsub  init_system_phase2()  {
 
 asmsub  cleanup_at_exit() {
     ; executed when the main subroutine does rts
+    ; TODO: Romable (I've decided not to do that yet)
     %asm {{
         lda  #1
         sta  $00        ; ram bank 1

--- a/compiler/res/prog8lib/math.asm
+++ b/compiler/res/prog8lib/math.asm
@@ -180,8 +180,9 @@ _inner_loop2
     ldy  result+1
     rts
 
-result		.byte  0,0,0,0       ; routine could be faster if this were in Zeropage...
-
+		.section BSS
+result		.byte  ?,?,?,?       ; routine could be faster if this were in Zeropage...
+		.send BSS
 		.pend
 
 
@@ -214,7 +215,9 @@ divmod_b_asm	.proc
 		adc  #0			; negate result
 		tay
 +		rts
-_remainder	.byte  0
+		.section BSS
+_remainder	.byte  ?
+		.send BSS
 		.pend
 
 
@@ -321,10 +324,12 @@ result = dividend ;save memory by reusing divident to store the result
 		lda  result
 		ldy  result+1
 		rts
-_divisor	.word 0
+		.section BSS
+_divisor	.word ?
+		.send BSS
 		.pend
 
-
+; TODO: Romable (find a way to init these variables. Maybe allocate them in slabs_BSS to make it even more random?)
 randword	.proc
 	; -- 16 bit pseudo random number generator into AY
 	;    default seed = $00c2 $1137

--- a/compiler/res/prog8lib/pet32/syslib.p8
+++ b/compiler/res/prog8lib/pet32/syslib.p8
@@ -374,10 +374,12 @@ _no_msb_size
             lda  P8ZP_SCRATCH_W2+1
             sta  save_SCRATCH_ZPWORD2+1
             rts
-save_SCRATCH_ZPB1	.byte  0
-save_SCRATCH_ZPREG	.byte  0
-save_SCRATCH_ZPWORD1	.word  0
-save_SCRATCH_ZPWORD2	.word  0
+            .section BSS
+save_SCRATCH_ZPB1	.byte  ?
+save_SCRATCH_ZPREG	.byte  ?
+save_SCRATCH_ZPWORD1	.word  ?
+save_SCRATCH_ZPWORD2	.word  ?
+            .send BSS
             ; !notreached!
         }}
     }
@@ -611,9 +613,11 @@ cx16 {
             bpl  -
             rts
 
+            .section BSS
     _cx16_vreg_storage
-            .word 0,0,0,0,0,0,0,0
-            .word 0,0,0,0,0,0,0,0
+            .word ?,?,?,?,?,?,?,?
+            .word ?,?,?,?,?,?,?,?
+            .send BSS
             ; !notreached!
         }}
     }
@@ -665,6 +669,7 @@ asmsub  init_system_phase2()  {
 
 asmsub  cleanup_at_exit() {
     ; executed when the main subroutine does rts
+    ; TODO: Romable
     %asm {{
 _exitcodeCarry = *+1
         lda  #0

--- a/compiler/res/prog8lib/prog8_funcs.asm
+++ b/compiler/res/prog8lib/prog8_funcs.asm
@@ -236,8 +236,10 @@ _l3		ldy  P8ZP_SCRATCH_B1           ;where the largest value shall be put
 		dec  P8ZP_SCRATCH_B1
 		bne  _sort_loop           ;start working with the shorter sequence
 		rts
-_work1	.byte  0
-_work3	.word  0
+		.section BSS
+_work1	.byte  ?
+_work3	.word  ?
+		.send BSS
 		.pend
 
 
@@ -299,8 +301,10 @@ _l3		ldy  P8ZP_SCRATCH_B1           ;where the largest value shall be put
 		dec  P8ZP_SCRATCH_B1
 		bne  _sort_loop           ;start working with the shorter sequence
 		rts
-_work1	.byte  0
-_work3	.word  0
+		.section BSS
+_work1	.byte  ?
+_work3	.word  ?
+		.send BSS
 		.pend
 
 

--- a/compiler/res/prog8lib/prog8_lib.asm
+++ b/compiler/res/prog8lib/prog8_lib.asm
@@ -1,9 +1,9 @@
 ; Internal library routines - always included by the compiler
 ; Generic machine independent 6502 code.
 
-
-orig_stackpointer	.byte  0	; stores the Stack pointer register at program start
-
+		.section BSS
+orig_stackpointer	.byte  ?	; stores the Stack pointer register at program start
+		.send BSS
 
 program_startup_clear_bss    .proc
 	; this is always ran first thing from the start routine to clear out the BSS area
@@ -166,17 +166,17 @@ _lastpage	ldy  P8ZP_SCRATCH_B1
 		bne  -
 
 +           	rts
-_save_reg	.byte  0
+		.section BSS
+_save_reg	.byte  ?
+		.send BSS
 		.pend
 
 
 memsetw		.proc
 	; -- fill memory from (P8ZP_SCRATCH_W1) number of words in P8ZP_SCRATCH_W2, with word value in AY.
 	;    clobbers A, X, Y
-		sta  _mod1+1                    ; self-modify
-		sty  _mod1b+1                   ; self-modify
-		sta  _mod2+1                    ; self-modify
-		sty  _mod2b+1                   ; self-modify
+		sta  _val                    ; this used to be self-modify
+		sty  _val+1
 		ldx  P8ZP_SCRATCH_W1
 		stx  P8ZP_SCRATCH_B1
 		ldx  P8ZP_SCRATCH_W1+1
@@ -188,11 +188,11 @@ memsetw		.proc
 		beq  _lastpage
 
 _fullpage
-_mod1           lda  #0                         ; self-modified
+		lda  _val
 		sta  (P8ZP_SCRATCH_W1),y        ; first page
 		sta  (P8ZP_SCRATCH_B1),y            ; second page
 		iny
-_mod1b		lda  #0                         ; self-modified
+		lda  _val+1
 		sta  (P8ZP_SCRATCH_W1),y        ; first page
 		sta  (P8ZP_SCRATCH_B1),y            ; second page
 		iny
@@ -209,12 +209,12 @@ _lastpage	ldx  P8ZP_SCRATCH_W2
 
 		ldy  #0
 -
-_mod2           lda  #0                         ; self-modified
-                sta  (P8ZP_SCRATCH_W1), y
+		lda  _val
+		sta  (P8ZP_SCRATCH_W1), y
 		inc  P8ZP_SCRATCH_W1
 		bne  _mod2b
 		inc  P8ZP_SCRATCH_W1+1
-_mod2b          lda  #0                         ; self-modified
+		lda  _val+1
 		sta  (P8ZP_SCRATCH_W1), y
 		inc  P8ZP_SCRATCH_W1
 		bne  +
@@ -222,6 +222,9 @@ _mod2b          lda  #0                         ; self-modified
 +               dex
 		bne  -
 _done		rts
+		.section BSS
+_val	.word ?
+		.send BSS
 		.pend
 
 
@@ -275,8 +278,10 @@ strcmp_expression	.proc
 		lda  _arg_s1
 		ldy  _arg_s1+1
 		jmp  strcmp_mem
-_arg_s1		.word  0
-_arg_s2		.word  0
+		.section BSS
+_arg_s1		.word  ?
+_arg_s2		.word  ?
+		.send BSS
 		.pend
 
 strcmp_mem	.proc
@@ -395,7 +400,7 @@ _found          lda  #1
 		rts
 	.pend
 
-
+; TODO: Romable
 arraycopy_split_to_normal_words .proc
 	; P8ZP_SCRATCH_W1 = start of lsb array
 	; P8ZP_SCRATCH_W2 = start of msb array
@@ -432,7 +437,7 @@ _modmsb         sta  $ffff       ; modified msb store
 		rts
 		.pend
 
-
+; TODO: Romable
 arraycopy_normal_to_split_words .proc
 	; P8ZP_SCRATCH_W1 = start of target lsb array
 	; P8ZP_SCRATCH_W2 = start of target msb array


### PR DESCRIPTION
This PR adjusts the low-level libraries, so that they can work in ROMed environments. In most cases, the problem was that these functions had helper variables defined inline. since none of them actually have any init value, we move the variables to BBS section (like prog8 codegen does) where we can ensure, that variables land safely in RAM.

When it comes to more controversial changes, conv.string_out is changed to `ubyte[16]` type. I don't think this change is going to break anything, since most of the time, those 2 types work identically and the variable is usually delegated to just internal stuff anyways.

There are 3 functions that are not fixed by this PR &ndash; `math.randword`, `prog8_lib.arraycopy_split_to_normal_words` and `arraycopy_normal_to_split_words`. All of them currently rely on self modifying code. 

The first one requires the 4 variables to be initialized to specific values. We could try to allocate them to the uninitialized slabs_BSS sections and yield results based on the uninitialized values, but this might be risky (some emulators may initialize all the memory to 0, or in general the existing values may yield results, that aren't too good).

The other two use self-modifying code for pointer access. The way prog8 creates .asm files doesn't allow low-level assembly code to allocate variables in zero-page, so it's not an easy fix like others. Changing them to pointer access may also decrease the execution speed of the function. The solution here might be to just create an alternative variants of the subroutines for ROMed targets and just use the new functions instead of the regular ones. still, ZP allocation might be a problem.