### PR TITLE
Make PET PLOT routine more efficient

### DIFF
--- a/compiler/res/prog8lib/pet32/textio.p8
+++ b/compiler/res/prog8lib/pet32/textio.p8
@@ -225,7 +225,7 @@ sub  setcc  (ubyte col, ubyte row, ubyte character, ubyte charcolor_ignored)  {
 
 asmsub  plot  (ubyte col @ Y, ubyte row @ X) {
 	%asm  {{
-        stx $d8
+		stx $d8
 		txa
 		asl a
 		tax

--- a/compiler/res/prog8lib/pet32/textio.p8
+++ b/compiler/res/prog8lib/pet32/textio.p8
@@ -225,15 +225,15 @@ sub  setcc  (ubyte col, ubyte row, ubyte character, ubyte charcolor_ignored)  {
 
 asmsub  plot  (ubyte col @ Y, ubyte row @ X) {
 	%asm  {{
-        txa
-        asl a
-        tax
-        lda setchr._screenrows,x
-        sta $c4
-        lda setchr._screenrows+1,x
-        sta $c5
-        sty $c6
- 		rts
+		txa
+		asl a
+		tax
+		lda setchr._screenrows,x
+		sta $c4
+		lda setchr._screenrows+1,x
+		sta $c5
+		sty $c6
+		rts
 	}}
 }
 

--- a/compiler/res/prog8lib/pet32/textio.p8
+++ b/compiler/res/prog8lib/pet32/textio.p8
@@ -225,20 +225,15 @@ sub  setcc  (ubyte col, ubyte row, ubyte character, ubyte charcolor_ignored)  {
 
 asmsub  plot  (ubyte col @ Y, ubyte row @ X) {
 	%asm  {{
-	    jsr  home
-	    cpy  #0
-	    beq  +
--	    lda  #29
-	    jsr  chrout
-	    dey
-	    bne  -
-+	    cpx  #0
-	    beq  +
--       lda  #17
-        jsr  chrout
-        dex
-        bne  -
-+		rts
+        txa
+        asl a
+        tax
+        lda setchr._screenrows,x
+        sta $c4
+        lda setchr._screenrows+1,x
+        sta $c5
+        sty $c6
+ 		rts
 	}}
 }
 

--- a/compiler/res/prog8lib/pet32/textio.p8
+++ b/compiler/res/prog8lib/pet32/textio.p8
@@ -225,6 +225,7 @@ sub  setcc  (ubyte col, ubyte row, ubyte character, ubyte charcolor_ignored)  {
 
 asmsub  plot  (ubyte col @ Y, ubyte row @ X) {
 	%asm  {{
+        stx $d8
 		txa
 		asl a
 		tax


### PR DESCRIPTION
Use the KERNAL screen state variables to move the cursor without having to print individual cursor-control characters, which is much more efficient.

Note that since it uses the screen line pointers table in the setchr() routine, it shares that routine's assumption of a 40-column display, while the cursor-key implementation also worked on an 80-column PET.