### PR TITLE
fix: add explicit dependency to make Gradle 9.0.0 happy

### DIFF
--- a/parser/build.gradle.kts
+++ b/parser/build.gradle.kts
@@ -21,6 +21,10 @@ tasks.compileJava {
     dependsOn(tasks.generateGrammarSource)
 }
 
+tasks.named("compileKotlin") {
+    dependsOn(tasks.generateGrammarSource)
+}
+
 sourceSets {
     main {
         java {


### PR DESCRIPTION
Fixes #175 