### PR TITLE
Fix error output file path: Encode to URI

### DIFF
--- a/codeCore/src/prog8/code/core/Position.kt
+++ b/codeCore/src/prog8/code/core/Position.kt
@@ -4,6 +4,7 @@ import prog8.code.sanitize
 import prog8.code.source.SourceCode
 import java.nio.file.InvalidPathException
 import kotlin.io.path.Path
+import kotlin.io.path.toPath
 
 data class Position(val file: String, val line: Int, val startCol: Int, val endCol: Int) {
     override fun toString(): String = "[$file: line $line col ${startCol}-${endCol}]"
@@ -21,8 +22,8 @@ data class Position(val file: String, val line: Int, val startCol: Int, val endC
         if(SourceCode.isLibraryResource(file))
             return "$file:$line:$startCol:"
         return try {
-            val path = Path(file).sanitize().toString()
-            "file://$path:$line:$startCol:"
+            val path = Path(file).sanitize().toUri().toString()
+            "$path:$line:$startCol:"
         } catch(_: InvalidPathException) {
             // this can occur on Windows when the source origin contains "invalid" characters such as ':'
             "file://$file:$line:$startCol:"


### PR DESCRIPTION
On Windows in VSCode I was getting unclickable links due to `\` vs `/` and spaces in my folder names. This encodes the output URI so that it's transformed into a proper `file://` path.