### PR TITLE
Don't require the BASIC launcher when the target has a custom launche…

### DIFF
--- a/compiler/src/prog8/compiler/Compiler.kt
+++ b/compiler/src/prog8/compiler/Compiler.kt
@@ -438,7 +438,7 @@ fun parseMainModule(filepath: Path,
         if(!compilerOptions.noSysInit)
             errors.err("library cannot use sysinit", program.toplevelModule.position)
     } else {
-        if (compilerOptions.launcher == CbmPrgLauncherType.BASIC && compilerOptions.output != OutputType.PRG)
+        if (compilerOptions.launcher == CbmPrgLauncherType.BASIC && compilerOptions.output != OutputType.PRG && compTarget.customLauncher.isEmpty())
             errors.err("BASIC launcher requires output type PRG", program.toplevelModule.position)
     }
 


### PR DESCRIPTION
…r defined.

A custom target with `custom_launcher_code` defined should, by definition, not require the BASIC launcher.
This makes this check consistent with the BASIC launcher load address check that already checks for a custom launcher.

This also makes using examples much easier with custom targets with custom launchers as it doesn't require editing each one to add `%launcher none` to compile.