### PR TITLE
Fix the swap documentation now that it's a statement and no longer a function

### DIFF
--- a/docs/source/libraries.rst
+++ b/docs/source/libraries.rst
@@ -286,11 +286,6 @@ sizeof (name)  ;  sizeof(datatype)  ;  sizeof(&name)  ;  sizeof(&&name)  ;  size
     For pointer types like ``^^float`` or ``^^MyStruct``, it returns the size of a pointer (2 bytes).
     Note: usually you will be interested in the number of elements in an array, or the number of characters in the string; use ``len()`` for that.
 
-:index:`swap` (var1, var2)
-    Swaps the values in var1 and var2 without the need of a temporary variable. Supports booleans and all other numeric datatypes including pointers.
-    Note that complicated expressions that you want to swap, may not be implemented yet. To avoid such errors you'll have to just swap them
-    in the old fashioned way, until an optimized code path gets implemented in a future Prog8 version.
-
 :index:`memory` (name, size, alignment)  ;  memory(name)
     Returns the address of the first location of a statically "reserved" block of memory with the given name.
     The 3-argument version reserves a block of the given size in bytes and optional alignment, and returns the address of it.

--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -930,20 +930,6 @@ as well, to assigns those multiple values. Details can be found here: :ref:`mult
     to a smaller datatype, or revert to integer arithmetic.
 
 
-swap statement
-^^^^^^^^^^^^^^
-.. index:: single: Swapping variables; swap
-
-The ``swap`` keyword swaps the values in two variables without the need of a temporary variable::
-
-    swap(var1, var2)
-
-Supports booleans and all other numeric datatypes including pointers. Note that complicated expressions
-that you want to swap may not be implemented yet. To avoid such errors you'll have to swap them
-in the old fashioned way (using a temporary variable), until an optimized code path gets implemented
-in a future Prog8 version.
-
-
 Expressions
 -----------
 .. index:: single: Expressions
@@ -1033,6 +1019,20 @@ and ``(true or false) and false`` is false instead of true.
         w = (b as word)*55
         w = b*(55 as word)
         w = b * $0037
+
+
+swap statement
+^^^^^^^^^^^^^^
+.. index:: single: Swapping variables; swap
+
+The ``swap`` keyword swaps the values in two variables without the need of a temporary variable::
+
+    swap(var1, var2)
+
+Supports booleans and all other numeric datatypes including pointers. Note that complicated expressions
+that you want to swap may not be implemented yet. To avoid such errors you'll have to swap them
+in the old fashioned way (using a temporary variable), until an optimized code path gets implemented
+in a future Prog8 version.
 
 
 Operators

--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -930,6 +930,20 @@ as well, to assigns those multiple values. Details can be found here: :ref:`mult
     to a smaller datatype, or revert to integer arithmetic.
 
 
+swap statement
+^^^^^^^^^^^^^^
+.. index:: single: Swapping variables; swap
+
+The ``swap`` keyword swaps the values in two variables without the need of a temporary variable::
+
+    swap(var1, var2)
+
+Supports booleans and all other numeric datatypes including pointers. Note that complicated expressions
+that you want to swap may not be implemented yet. To avoid such errors you'll have to swap them
+in the old fashioned way (using a temporary variable), until an optimized code path gets implemented
+in a future Prog8 version.
+
+
 Expressions
 -----------
 .. index:: single: Expressions

--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -1022,7 +1022,7 @@ and ``(true or false) and false`` is false instead of true.
 
 
 swap statement
-^^^^^^^^^^^^^^
+--------------
 .. index:: single: Swapping variables; swap
 
 The ``swap`` keyword swaps the values in two variables without the need of a temporary variable::


### PR DESCRIPTION
- Removed the description from the functions.
- Added a description to the programming > assignments section.